### PR TITLE
feat: MM-13 edit and delete methods in sql adapter

### DIFF
--- a/adapters/src/repositories/memory/memory_recipe_repository.py
+++ b/adapters/src/repositories/memory/memory_recipe_repository.py
@@ -41,7 +41,7 @@ class MemoryRecipeRepository(RecipeRepository):
         except Exception:
             raise RecipeRepositoryException(method="list")
 
-    def delete(self, recipe_id: str) -> Optional[Recipe]:
+    def delete(self, recipe_id: str) -> bool:
         try:
             recipe = self.get_by_id(recipe_id)
             if recipe is not None:
@@ -58,7 +58,7 @@ class MemoryRecipeRepository(RecipeRepository):
                 )
                 self.recipes.remove(recipe)
                 self.recipes.append(modified_recipe)
-                return modified_recipe
-            return None
+                return True
+            return False
         except Exception:
             raise RecipeRepositoryException(method="delete")

--- a/adapters/src/repositories/sql/sql_recipe_repository.py
+++ b/adapters/src/repositories/sql/sql_recipe_repository.py
@@ -52,8 +52,23 @@ class SQLRecipeRepository(RecipeRepository):
             self.session.rollback()
             raise RecipeRepositoryException(method="get_by_id")
 
-    def edit(self, recipe: Recipe) -> Optional[Recipe]:
-        return None
+    def edit(self, updated_recipe: Recipe) -> Optional[Recipe]:
+        try:
+            recipe_to_edit = self.session.query(RecipeRecord).filter_by(
+                recipe_id=updated_recipe.recipe_id).first()
+            if recipe_to_edit is None:
+                return None
+            recipe_to_edit.title = updated_recipe.title  # type: ignore
+            recipe_to_edit.description = updated_recipe.description  # type: ignore
+            recipe_to_edit.ingredients = updated_recipe.ingredients  # type: ignore
+            recipe_to_edit.steps = updated_recipe.steps  # type: ignore
+            recipe_to_edit.image_url = updated_recipe.image_url  # type: ignore
+            recipe_to_edit.updated_at = updated_recipe.updated_at  # type: ignore
+            self.session.commit()
+            return updated_recipe
+        except Exception:
+            self.session.rollback()
+            raise RecipeRepositoryException(method="edit")
 
     def delete(self, recipe_id: str) -> Optional[Recipe]:
         return None

--- a/adapters/tests/fixtures/recipe_fixtures.py
+++ b/adapters/tests/fixtures/recipe_fixtures.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -15,6 +15,22 @@ def mock_recipe() -> Recipe:
         steps=["step1", "step2"],
         image_url="https://test.com/test.jpg",
         is_archived=False,
-        created_at=datetime.datetime.now(),
-        updated_at=datetime.datetime.now(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+@pytest.fixture
+def mock_updated_recipe() -> Recipe:
+    current_datetime = datetime.now()
+    return Recipe(
+        recipe_id=1,
+        title="Test Recipe Updated",
+        description="Test Description Updated",
+        ingredients=["ingredient1 Updated", "ingredient2 Updated"],
+        steps=["step1 Updated", "step2 Updated"],
+        image_url="https://test.com/test_updated.jpg",
+        is_archived=False,
+        created_at=current_datetime - timedelta(days=1),
+        updated_at=current_datetime,
     )

--- a/adapters/tests/fixtures/recipe_fixtures.py
+++ b/adapters/tests/fixtures/recipe_fixtures.py
@@ -34,3 +34,19 @@ def mock_updated_recipe() -> Recipe:
         created_at=current_datetime - timedelta(days=1),
         updated_at=current_datetime,
     )
+
+
+@pytest.fixture
+def mock_deleted_recipe() -> Recipe:
+    current_datetime = datetime.now()
+    return Recipe(
+        recipe_id=1,
+        title="Test Deleted Recipe",
+        description="Test Description",
+        ingredients=["ingredient1", "ingredient2"],
+        steps=["step1", "step2"],
+        image_url="https://test.com/test.jpg",
+        is_archived=True,
+        created_at=current_datetime - timedelta(days=1),
+        updated_at=datetime.now(),
+    )

--- a/adapters/tests/fixtures/session_fixtures.py
+++ b/adapters/tests/fixtures/session_fixtures.py
@@ -1,7 +1,9 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from sqlalchemy.orm import Session
+
+from adapters.src.repositories.sql import RecipeRecord
 
 
 @pytest.fixture(scope='function')
@@ -51,3 +53,25 @@ def mock_session_query_get_by_id_return_none() -> MagicMock:
     mock_query.filter.return_value = mock_query
     mock_query.first.return_value = None
     return mock_session
+
+
+@pytest.fixture(scope='function')
+def mock_session_query_delete_recipe(mock_deleted_recipe) -> MagicMock:
+    session = MagicMock(spec=Session)
+    mock_query = MagicMock()
+
+    mock_recipe_record = create_autospec(RecipeRecord, instance=True, spec_set=True)
+
+    mock_recipe_record.recipe_id = mock_deleted_recipe.recipe_id
+    mock_recipe_record.title = mock_deleted_recipe.title
+    mock_recipe_record.description = mock_deleted_recipe.description
+    mock_recipe_record.ingredients = mock_deleted_recipe.ingredients
+    mock_recipe_record.steps = mock_deleted_recipe.steps
+    mock_recipe_record.image_url = mock_deleted_recipe.image_url
+    mock_recipe_record.is_archived = mock_deleted_recipe.is_archived
+    mock_recipe_record.created_at = mock_deleted_recipe.created_at
+    mock_recipe_record.updated_at = mock_deleted_recipe.updated_at
+
+    mock_query.filter_by().first.return_value = mock_recipe_record
+    session.query.return_value = mock_query
+    return session

--- a/adapters/tests/repositories/sql/recipe/test_delete_recipe_sql_adapter.py
+++ b/adapters/tests/repositories/sql/recipe/test_delete_recipe_sql_adapter.py
@@ -1,0 +1,24 @@
+import pytest
+
+from adapters.src.repositories import SQLRecipeRepository
+from adapters.src.repositories.sql.config.session_manager import Session
+from core.src.exceptions import RecipeRepositoryException
+from core.src.models import Recipe
+
+
+def test_delete_recipe_when_it_is_found_should_return_deleted_recipe(
+        mock_session_query_delete_recipe: Session, mock_recipe: Recipe):
+    recipe_sql_repository = SQLRecipeRepository(session=mock_session_query_delete_recipe)
+
+    deleted_recipe = recipe_sql_repository.delete(recipe_id=mock_recipe.recipe_id)
+
+    assert deleted_recipe is True
+
+
+def test_delete_recipe_when_exception_occurs_should_raise_repository_exception(
+        mock_session_query_exception: Session, mock_recipe: Recipe):
+    recipe_sql_repository = SQLRecipeRepository(session=mock_session_query_exception)
+    message = "Something was wrong trying to delete the Recipe"
+
+    with pytest.raises(RecipeRepositoryException, match=message):
+        recipe_sql_repository.delete(recipe_id=mock_recipe.recipe_id)

--- a/adapters/tests/repositories/sql/recipe/test_edit_recipe_sql_adapter.py
+++ b/adapters/tests/repositories/sql/recipe/test_edit_recipe_sql_adapter.py
@@ -1,0 +1,26 @@
+import pytest
+
+from adapters.src.repositories import SQLRecipeRepository
+from adapters.src.repositories.sql.config.session_manager import Session
+from core.src.exceptions import RecipeRepositoryException
+from core.src.models import Recipe
+
+
+def test_edit_recipe_when_it_is_found_should_return_updated_recipe(
+        mock_session: Session, mock_updated_recipe: Recipe):
+    recipe_sql_repository = SQLRecipeRepository(session=mock_session)
+
+    updated_recipe = recipe_sql_repository.edit(updated_recipe=mock_updated_recipe)
+
+    assert updated_recipe is not None
+    assert isinstance(updated_recipe, Recipe)
+    assert updated_recipe == mock_updated_recipe
+
+
+def test_edit_recipe_when_exception_occurs_should_raise_repository_exception(
+        mock_session_query_exception: Session, mock_updated_recipe: Recipe):
+    recipe_sql_repository = SQLRecipeRepository(session=mock_session_query_exception)
+    message = "Something was wrong trying to edit the Recipe"
+
+    with pytest.raises(RecipeRepositoryException, match=message):
+        recipe_sql_repository.edit(updated_recipe=mock_updated_recipe)

--- a/core/src/repository/recipe_repository.py
+++ b/core/src/repository/recipe_repository.py
@@ -18,7 +18,7 @@ class RecipeRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def delete(self, recipe_id: str) -> Optional[Recipe]:
+    def delete(self, recipe_id: str) -> bool:
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
#### 🤔 Why?

Add the logic to:
- Edit a recipe
- Delete a recipe

#### 🛠 What I changed:

- Edit and delete logic for SQL adapter
- Change the return value in repositories (Recipe by bool, to return the new status of the Recipe [archived or not] )
- Tests for edit and delete SQL adapter
- Add necessary fixtures to simulate the behavior of the adapter

#### 🗃️ Trello Issues:

[MM-13: Edit and delete method for Recipe entity in SQL adapter](https://trello.com/c/2dGXx3mg)

#### 🚦 Functional Testing Results:

![image](https://github.com/hayleencc/meal-muse-backend-v1/assets/66764846/42786383-67aa-4e6d-881c-660790532f55)