### PR TITLE
feat/HC: MM-17 add logic and tests for list recipes endpoint

### DIFF
--- a/api/src/routers/recipe_router.py
+++ b/api/src/routers/recipe_router.py
@@ -1,9 +1,11 @@
+from typing import List
+
 from fastapi import APIRouter, HTTPException
 
 from api.src.dtos import Recipe
 from core.src.exceptions.business import BusinessException
-from core.src.use_cases import CreateRecipe, CreateRecipeRequest
-from factories.use_cases import create_recipe_use_case
+from core.src.use_cases import CreateRecipe, CreateRecipeRequest, ListRecipe
+from factories.use_cases import create_recipe_use_case, list_recipes_use_case
 
 recipe_router = APIRouter(
     prefix="/recipes",
@@ -25,6 +27,17 @@ async def create_recipe(recipe: Recipe) -> Recipe:
         create_use_case: CreateRecipe = create_recipe_use_case()
         response = create_use_case(request=request)
         return Recipe(**response._asdict())
+
+    except BusinessException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@recipe_router.get("/")
+async def get_recipes() -> List[Recipe]:
+    try:
+        list_use_case: ListRecipe = list_recipes_use_case()
+        response = list_use_case()
+        return [Recipe(**recipe._asdict()) for recipe in response.recipes] if response.recipes else []
 
     except BusinessException as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/api/tests/fixtures/recipe_fixtures.py
+++ b/api/tests/fixtures/recipe_fixtures.py
@@ -1,7 +1,7 @@
 import pytest
 
-from api.src.dtos import Recipe
-from core.src.use_cases.recipe import CreateRecipeResponse
+from core.src.models import Recipe
+from core.src.use_cases.recipe import CreateRecipeResponse, ListRecipeResponse
 
 
 @pytest.fixture
@@ -20,7 +20,7 @@ def recipe_request_data() -> dict:
 
 
 @pytest.fixture
-def create_recipe_response() -> Recipe:
+def create_recipe_response():
     return {
         "recipe_id": "f7e0d1e1-6b5d-4f0a-9e9b-1a3b1e7b8f0f",
         "title": "Recipe 1",
@@ -48,3 +48,38 @@ def create_recipe_response_use_case() -> CreateRecipeResponse:
         updated_at="2021-01-01T00:00:00",
 
     )
+
+
+@pytest.fixture
+def list_recipes_response():
+    return [
+        {
+            "recipe_id": str(recipe_id+1),
+            "title": "Recipe " + str(recipe_id+1),
+            "description": "Description",
+            "ingredients": ["Ingredient 1", "Ingredient 2"],
+            "steps": ["Step 1", "Step 2"],
+            "image_url": "https:/mage.com/image.jpg",
+            "is_archived": False,
+            "created_at": "2021-01-01T00:00:00",
+            "updated_at": "2021-01-01T00:00:00",
+        } for recipe_id in range(3)
+    ]
+
+
+@pytest.fixture
+def list_recipes_response_use_case() -> ListRecipeResponse:
+    recipes = [
+        Recipe(
+            recipe_id=str(i+1),
+            title="Recipe " + str(i+1),
+            description="Description",
+            ingredients=["Ingredient 1", "Ingredient 2"],
+            steps=["Step 1", "Step 2"],
+            image_url="https:/mage.com/image.jpg",
+            is_archived=False,
+            created_at="2021-01-01T00:00:00",
+            updated_at="2021-01-01T00:00:00",
+        ) for i in range(3)
+    ]
+    return ListRecipeResponse(recipes=recipes)

--- a/api/tests/routers/test_list_all_recipe_router.py
+++ b/api/tests/routers/test_list_all_recipe_router.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from core.src.exceptions.business import BusinessException
+from core.src.use_cases.recipe import ListRecipe, ListRecipeResponse
+
+
+def test__list_all_recipes__when_there_are_no_recipes__then_it_should_return_empty_list_and_status_code_200(
+        client_session):
+
+    with patch.object(ListRecipe, "__call__", return_value=ListRecipeResponse(recipes=[])):
+        response = client_session.get("/recipes/")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test__list_all_recipes__when_it_is_called__then_it_should_return_recipes_and_status_code_200(
+        list_recipes_response_use_case: ListRecipeResponse, list_recipes_response,
+        client_session):
+
+    with patch.object(ListRecipe, "__call__", return_value=list_recipes_response_use_case):
+        response = client_session.get("/recipes/")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+    assert response.json() == list_recipes_response
+
+
+def test__list_all_recipes__when_it_is_called__then_it_should_return_status_code_400_and_error_message(
+        client_session):
+
+    error_message = "There was an error listing the recipes."
+
+    with patch.object(ListRecipe, "__call__", side_effect=BusinessException(error_message)):
+        response = client_session.get("/recipes/")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": error_message}


### PR DESCRIPTION
#### 🤔 Why?

Add the endpoint to list all the recipes that were saved.

#### 🛠 What I changed:

- Add endpoint in the recipes router
- Add tests to list recipes endpoint
- Create fixtures to test the list of recipes endpoint

#### 🗃️ Trello Issues:

[MM-17: Add ListRecipes endpoint in API layer](https://trello.com/c/DPzrcnTJ)

#### 🚦 Functional Testing Results:

![image](https://github.com/user-attachments/assets/faca5f5d-53ed-46d7-bad2-24ab92b2cc5b)
