### PR TITLE
fix/HC: MM-21 Refactor Edit use case for allowing a patch

### DIFF
--- a/adapters/src/repositories/sql/sql_recipe_repository.py
+++ b/adapters/src/repositories/sql/sql_recipe_repository.py
@@ -68,7 +68,6 @@ class SQLRecipeRepository(RecipeRepository):
             recipe_to_edit.ingredients = updated_recipe.ingredients  # type: ignore
             recipe_to_edit.steps = updated_recipe.steps  # type: ignore
             recipe_to_edit.image_url = updated_recipe.image_url  # type: ignore
-            recipe_to_edit.updated_at = updated_recipe.updated_at  # type: ignore
             self.session.commit()
             return updated_recipe
 

--- a/core/src/exceptions/__init__.py
+++ b/core/src/exceptions/__init__.py
@@ -2,6 +2,7 @@ from .business import (
     RecipeBusinessException,
     RecipeCreateException,
     RecipeNoneException,
+    RecipeNotDataException,
     RecipeNotFoundException,
 )
 from .repository import RecipeRepositoryException

--- a/core/src/exceptions/business/__init__.py
+++ b/core/src/exceptions/business/__init__.py
@@ -3,11 +3,13 @@ from .base import (
     BusinessException,
     CreateException,
     NoneException,
+    NotDataException,
     NotFoundException,
 )
 from .recipe import (
     RecipeBusinessException,
     RecipeCreateException,
     RecipeNoneException,
+    RecipeNotDataException,
     RecipeNotFoundException,
 )

--- a/core/src/exceptions/business/base.py
+++ b/core/src/exceptions/business/base.py
@@ -24,3 +24,9 @@ class NoneException(BusinessException):
     def __init__(self, entity_type: str):
         message = f"The {entity_type} is None."
         super().__init__(message)
+
+
+class NotDataException(BusinessException):
+    def __init__(self, entity_type: str):
+        message = f"The {entity_type} does not have data to update."
+        super().__init__(message)

--- a/core/src/exceptions/business/recipe.py
+++ b/core/src/exceptions/business/recipe.py
@@ -18,3 +18,8 @@ class RecipeNotFoundException(NotFoundException):
 class RecipeNoneException(BusinessException):
     def __init__(self, entity_id: str) -> None:
         super().__init__(entity_type="Recipe", entity_id=entity_id)
+
+
+class RecipeNotDataException(BusinessException):
+    def __init__(self) -> None:
+        super().__init__(entity_type="Recipe")

--- a/core/src/use_cases/recipe/edit/request.py
+++ b/core/src/use_cases/recipe/edit/request.py
@@ -1,12 +1,10 @@
-from datetime import datetime
 from typing import List, NamedTuple, Optional
 
 
 class EditRecipeRequest(NamedTuple):
     recipe_id: str
-    title: str
-    description: str
-    ingredients: List[str]
-    steps: List[str]
-    image_url: Optional[str]
-    updated_at: Optional[datetime | str]
+    title: Optional[str] = None
+    description: Optional[str] = None
+    steps: Optional[List[str]] = None
+    ingredients: Optional[List[str]] = None
+    image_url: Optional[str] = None

--- a/core/src/use_cases/recipe/edit/use_case.py
+++ b/core/src/use_cases/recipe/edit/use_case.py
@@ -3,6 +3,7 @@ from typing import Optional
 from core.src.exceptions import (
     RecipeBusinessException,
     RecipeNoneException,
+    RecipeNotDataException,
     RecipeNotFoundException,
     RecipeRepositoryException,
 )
@@ -21,7 +22,17 @@ class EditRecipe():
             recipe = self.recipe_repository.get_by_id(request.recipe_id)
             if recipe is None:
                 raise RecipeNotFoundException(recipe_id=request.recipe_id)
-            updated_recipe = Recipe(**{**recipe._asdict(), **request._asdict()})
+
+            updated_data = {
+                key: value
+                for key, value in request._asdict().items()
+                if value is not None
+            }
+
+            if not updated_data:
+                raise RecipeNotDataException()
+
+            updated_recipe = Recipe(**{**recipe._asdict(), **updated_data})
             response = self.recipe_repository.edit(updated_recipe)
 
             if not response:

--- a/core/tests/fixtures/recipe_fixtures.py
+++ b/core/tests/fixtures/recipe_fixtures.py
@@ -71,7 +71,7 @@ def get_recipe_by_id_response_core() -> GetRecipeByIdResponse:
 
 
 @pytest.fixture
-def edit_recipe_response() -> EditRecipeResponse:
+def edit_recipe_response_core() -> EditRecipeResponse:
     now = datetime.now()
     created_date = now.strftime("%d/%m/%Y %H:%M:%S")
     recipe_request = EditRecipeResponse(
@@ -79,10 +79,10 @@ def edit_recipe_response() -> EditRecipeResponse:
         title="New title",
         description="New description",
         ingredients=["New ingredient"],
-        steps=["New step"],
+        steps=["step_1", "step_2"],
         image_url="http://new_image.com",
         is_archived=False,
         created_at=created_date,
-        updated_at=None,
+        updated_at=created_date,
     )
     return recipe_request

--- a/core/tests/use_cases/recipe/edit/test_edit_recipe_use_case.py
+++ b/core/tests/use_cases/recipe/edit/test_edit_recipe_use_case.py
@@ -20,7 +20,7 @@ from core.src.use_cases import (
 def test_edit_recipe_should_return_edited_recipe_when_recipe_exists(
     recipe_repository: MemoryRecipeRepository,
     recipe_create_request: CreateRecipeRequest,
-    edit_recipe_response: EditRecipeResponse,
+    edit_recipe_response_core: EditRecipeResponse,
 ):
     create_recipe_use_case = CreateRecipe(recipe_repository)
     create_recipe_use_case(recipe_create_request)
@@ -31,13 +31,11 @@ def test_edit_recipe_should_return_edited_recipe_when_recipe_exists(
         title="New title",
         description="New description",
         ingredients=["New ingredient"],
-        steps=["New step"],
         image_url="http://new_image.com",
-        updated_at=None,
     )
     response = edit_recipe_use_case(request=request)
 
-    assert response == edit_recipe_response
+    assert response == edit_recipe_response_core
 
 
 def test_edit_recipe_when_recipe_does_not_exist_should_raise_exception(
@@ -51,7 +49,6 @@ def test_edit_recipe_when_recipe_does_not_exist_should_raise_exception(
         ingredients=["New ingredient"],
         steps=["New step"],
         image_url="http://new_image.com",
-        updated_at=None,
     )
 
     with pytest.raises(RecipeNotFoundException):
@@ -72,7 +69,6 @@ def test_edit_recipe_should_raise_exception_when_repository_fails(
         ingredients=["New ingredient"],
         steps=["New step"],
         image_url="http://new_image.com",
-        updated_at=None,
     )
 
     with patch.object(MemoryRecipeRepository, "edit", side_effect=RecipeRepositoryException("edit")):


### PR DESCRIPTION
#### 🤔 Why?

Currently, the API layer is receiving an entire recipe to be edited. Still, the recommended is to receive just the attributes that will be modified, so it is necessary to allow these changes from the core layer. Also, consider that it can be changed into the adapters.

#### 🛠 What I changed:

- Add NotDataException to handle where there is no data to update
- Allow the request to have optional attributes, just to send the necessary and not all of them 
- Add the logic to allow to edit one or more attributes of a recipe 
- Fix the tests according to the added logic

#### 🗃️ Trello Issues:

[MM-21: Refactor Edit use case for allowing a patch](https://trello.com/c/LW8tuHVC)

#### 🚦 Functional Testing Results:

![image](https://github.com/user-attachments/assets/535c7a3c-145c-4aa5-9e67-03ed4ec316bf)