### PR TITLE
feat: MM-20 delete recipe endpoint in api layer

### DIFF
--- a/api/src/dtos/__init__.py
+++ b/api/src/dtos/__init__.py
@@ -1,1 +1,1 @@
-from .recipe_dto import Recipe
+from .recipe_dto import Recipe, RecipeDeleted

--- a/api/src/dtos/recipe_dto.py
+++ b/api/src/dtos/recipe_dto.py
@@ -14,3 +14,8 @@ class Recipe(BaseModel):
     updated_at: Optional[datetime]
     is_archived: Optional[bool] = False
     recipe_id: Optional[str] = None
+
+
+class RecipeDeleted(BaseModel):
+    recipe_id: str
+    is_archived: bool

--- a/api/src/routers/recipe_router.py
+++ b/api/src/routers/recipe_router.py
@@ -2,11 +2,13 @@ from typing import List
 
 from fastapi import APIRouter, HTTPException
 
-from api.src.dtos import Recipe
+from api.src.dtos import Recipe, RecipeDeleted
 from core.src.exceptions.business import BusinessException
 from core.src.use_cases import (
     CreateRecipe,
     CreateRecipeRequest,
+    DeleteRecipe,
+    DeleteRecipeRequest,
     EditRecipe,
     EditRecipeRequest,
     GetRecipeById,
@@ -15,6 +17,7 @@ from core.src.use_cases import (
 )
 from factories.use_cases import (
     create_recipe_use_case,
+    delete_recipe_use_case,
     edit_recipe_use_case,
     get_recipe_by_id_use_case,
     list_recipes_use_case,
@@ -87,3 +90,18 @@ async def edit_recipe(recipe: Recipe) -> Recipe:
 
     except BusinessException as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@recipe_router.delete("/{recipe_id}")
+async def delete_recipe(recipe_id: str) -> RecipeDeleted:
+    try:
+        request = DeleteRecipeRequest(recipe_id=recipe_id)
+        delete_use_case: DeleteRecipe = delete_recipe_use_case()
+        response = delete_use_case(request=request)
+        return RecipeDeleted(recipe_id=recipe_id, is_archived=response.is_archived)  # type: ignore
+
+    except BusinessException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    except Exception:
+        raise HTTPException(status_code=500, detail="An unexpected error occurred")

--- a/api/tests/fixtures/recipe_fixtures.py
+++ b/api/tests/fixtures/recipe_fixtures.py
@@ -3,6 +3,7 @@ import pytest
 from core.src.models import Recipe
 from core.src.use_cases.recipe import (
     CreateRecipeResponse,
+    DeleteRecipeResponse,
     EditRecipeResponse,
     GetRecipeByIdResponse,
     ListRecipeResponse,
@@ -148,3 +149,21 @@ def edit_recipe_response():
         "created_at": "2021-01-01T00:00:00",
         "updated_at": "2021-01-01T00:00:00",
     }
+
+
+@pytest.fixture
+def delete_recipe_use_case():
+    return DeleteRecipeResponse(is_archived=True)
+
+
+@pytest.fixture
+def delete_recipe_response():
+    return {
+        "is_archived": True,
+        "recipe_id": "f7e0d1e1-6b5d-4f0a-9e9b-1a3b1e7b8f0f",
+    }
+
+
+@pytest.fixture
+def recipe_id():
+    return "f7e0d1e1-6b5d-4f0a-9e9b-1a3b1e7b8f0f"

--- a/api/tests/routers/test_delete_recipe_router.py
+++ b/api/tests/routers/test_delete_recipe_router.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from api.src.dtos import RecipeDeleted
+from core.src.exceptions.business import BusinessException
+from core.src.use_cases import DeleteRecipe, DeleteRecipeResponse
+
+
+def test__delete_recipe__when_it_is_called__then_it_should_return_recipe_is_archived_in_true(
+        recipe_id: str, delete_recipe_response:
+        RecipeDeleted, delete_recipe_use_case:
+        DeleteRecipeResponse, client_session
+):
+
+    with patch.object(DeleteRecipe, "__call__", return_value=delete_recipe_use_case):
+        response = client_session.delete(f"/recipes/{recipe_id}")
+
+    assert response.status_code == 200
+    assert response.json() == delete_recipe_response
+
+
+def test__delete_recipe__when_it_is_called_and_business_exception_is_raised__then_it_should_return_status_code_400(
+        recipe_id: str, client_session):
+
+    with patch.object(DeleteRecipe, "__call__", side_effect=BusinessException()):
+        response = client_session.delete(f"/recipes/{recipe_id}")
+
+    assert response.status_code == 400

--- a/core/src/use_cases/recipe/delete/response.py
+++ b/core/src/use_cases/recipe/delete/response.py
@@ -2,4 +2,4 @@ from typing import NamedTuple
 
 
 class DeleteRecipeResponse(NamedTuple):
-    is_recipe_archived: bool
+    is_archived: bool

--- a/core/src/use_cases/recipe/delete/use_case.py
+++ b/core/src/use_cases/recipe/delete/use_case.py
@@ -18,6 +18,6 @@ class DeleteRecipe():
             if recipe is None:
                 raise RecipeNotFoundException(recipe_id=request.recipe_id)
             response = self.recipe_repository.delete(request.recipe_id)
-            return DeleteRecipeResponse(is_recipe_archived=bool(response))
+            return DeleteRecipeResponse(is_archived=bool(response))
         except RecipeRepositoryException as e:
             raise RecipeBusinessException(str(e))

--- a/core/tests/use_cases/recipe/delete/test_delete_recipe_use_case.py
+++ b/core/tests/use_cases/recipe/delete/test_delete_recipe_use_case.py
@@ -30,7 +30,7 @@ def test_delete_recipe_when_a_recipe_exists_should_return_true(
 
     assert response is not None
     assert isinstance(response, DeleteRecipeResponse)
-    assert response.is_recipe_archived is True
+    assert response.is_archived is True
 
 
 def test_delete_recipe_when_it_does_not_exist_should_raise_exception(


### PR DESCRIPTION
#### 🤔 Why?

Add the endpoint to delete a recipe using the DELETE method. Consider that this is a logic delete.


#### 🛠 What I changed:

- Change the `is_recipe_archived` attribute to `is_archived` to keep the same used in other use cases.
- Add the logic to delete a recipe.
- Add the tests for the logic of deleting a recipe.
- Create a DTO for the delete response, because it will not retrieve all the attributes as in the previous methods.
 
#### 🗃️ Trello Issues:

[MM-20: Add DeleteRecipe endpoint in API layer](https://trello.com/c/HT1ZbuZ2)
#### 🚦 Functional Testing Results:

![image](https://github.com/user-attachments/assets/f94d6830-3cae-481b-b750-d1d80c21110f)
